### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: .NET
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/omgitsjan/Starter-DiscordBotAI/security/code-scanning/2](https://github.com/omgitsjan/Starter-DiscordBotAI/security/code-scanning/2)

To fix the issue, add an explicit `permissions` block at the root of the workflow to limit the `GITHUB_TOKEN` permissions. Because the workflow primarily performs build and test operations, it does not require `write` permissions. Setting `contents: read` as the only permission ensures that the workflow can read repository contents but cannot make any changes.

The `permissions` block should be added directly below the `name` key at the top level of the workflow file. This ensures that the minimal permissions apply to all jobs within the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
