### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,5 +1,8 @@
 name: Build and Push Docker Image
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [created]


### PR DESCRIPTION
Potential fix for [https://github.com/omgitsjan/Starter-DiscordBotAI/security/code-scanning/1](https://github.com/omgitsjan/Starter-DiscordBotAI/security/code-scanning/1)

To address this issue, we need to explicitly set the `permissions` block in the workflow. Since the workflow involves building and pushing a Docker image but does not interact with repository contents (e.g., modifying files), the minimal required permissions should be set. The `contents: read` permission is sufficient for read-only access to the repository's contents, which might be necessary for the checkout step.

The `permissions` block should be added at the root level of the workflow to apply to all jobs. This ensures that the `GITHUB_TOKEN` permissions are restricted for the entire workflow unless explicitly overridden in individual jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
